### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/templates/copy_lambda.template.yaml
+++ b/templates/copy_lambda.template.yaml
@@ -167,7 +167,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt 'CreateSpotinstLambdaRole.Arn'
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 120
       Code:
         S3Bucket: !Ref 'LambdaZipsBucket'


### PR DESCRIPTION
CloudFormation templates in quickstart-spotinst-eks have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.